### PR TITLE
[Fix] Fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can see the translation data if you hover your mouse on i18n code.
 This extension contributes the following variables to the settings:
 
 - `i18n-Lens.translatorFunctionName`: The name of translator function you use. Default value it `t`
-- `i18n-Lens.localeDirectoryPath`: The path where translation files are located. Default value is `/**/locales`
+- `i18n-Lens.localeDirectoryPath`: The path where translation files are located. Default value is `/locales`
 
 ## Getting Started
 
@@ -36,7 +36,7 @@ Setup options of i18n-Lens.
 {
   ...
   "i18n-Lens.translatorFunctionName": "translate",
-  "i18n-Lens.localeDirectoryPath": "/**/locales"
+  "i18n-Lens.localeDirectoryPath": "/locales"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "i18n-Lens.localeDirectoryPath": {
           "type": "string",
           "description": "Language translation file directory path",
-          "default": "/**/locales"
+          "default": "/locales"
         }
       }
     }

--- a/src/core/I18nController.ts
+++ b/src/core/I18nController.ts
@@ -41,11 +41,11 @@ class I18n {
     if (key.includes(':')) {
       const [division, subKey] = key.split(':');
       return (
-        this.layeredDictionary?.[division]?.[subKey].replace(/\n/g, '\\n') ||
+        this.layeredDictionary?.[division]?.[subKey]?.replace(/\n/g, '\\n') ||
         '-'
       );
     }
-    return this.dictionary?.[key].replace(/\n/g, '\\n') || '-';
+    return this.dictionary?.[key]?.replace(/\n/g, '\\n') || '-';
   }
 }
 
@@ -117,9 +117,13 @@ class I18nController {
 export async function getI18nControllerList(
   workspaceFolders: readonly vscode.WorkspaceFolder[],
 ) {
+  const rootPathList = workspaceFolders.map(
+    (workspaceFolder) => workspaceFolder.uri.fsPath,
+  );
+  const orderedRootPathList = rootPathList.sort((l, r) => r.length - l.length);
   return await Promise.all(
-    workspaceFolders.map((workspaceFolder) => {
-      return I18nController.init(workspaceFolder.uri.fsPath);
+    orderedRootPathList.map((rootPath) => {
+      return I18nController.init(rootPath);
     }) || [],
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ export async function activate(context: vscode.ExtensionContext) {
             vscode.window.activeTextEditor?.document.uri.path;
           return currentDocumentPath?.includes(i18nController.rootPath);
         });
-        if (!i18nController) {
+        if (!i18nController?.i18nList.length) {
           return;
         }
 


### PR DESCRIPTION
- Add optional chaining inside the `i18n.internationalize` method.
- Prevent tooltip from activating when registered ` i18nController.i18nList` does not exists.
- Set default value of `localeDirectoryPath` from `/**/locales` to   `/locales`.
- Sort workspace folders by order of path length.