### PR TITLE
[Fix] Update type

### DIFF
--- a/src/core/DictionaryHandler.ts
+++ b/src/core/DictionaryHandler.ts
@@ -5,7 +5,7 @@
  */
 
 import { flattenDictionary } from '../utils';
-import { Dictionary } from '../types';
+import type { Dictionary } from '../types';
 
 class DictionaryHandler {
   localePath: string;
@@ -23,17 +23,23 @@ class DictionaryHandler {
     this.flattenedDictionary = flattenDictionary(dictionary);
   }
 
-  internationalize(locale: string, key: string) {
-    const translatedValue = (() => {
+  internationalize(locale: string, key: string): string {
+    const translatedValue: string = (() => {
       // If no delimiter exists, use this.flattenedDictionary to quickly get the translated value.
       if (!key.includes(':')) {
-        return (this.flattenedDictionary?.[locale] as Dictionary)?.[key];
+        const localeFlattenedDictionary = this.flattenedDictionary[
+          locale
+        ] as Dictionary;
+        return localeFlattenedDictionary?.[key] as string;
       }
 
       // If delimiter exists, travel this.dictionary to get the translated value.
-      return key.split(':').reduce((value: any, key) => {
-        return value?.[key];
-      }, this.dictionary[locale]);
+      return key.split(':').reduce((value, subKey) => {
+        if (typeof value === 'string') {
+          return value;
+        }
+        return value?.[subKey];
+      }, this.dictionary[locale]) as string;
     })();
 
     return translatedValue?.replace(/\n/g, '\\n') || '-';

--- a/src/core/I18nController.ts
+++ b/src/core/I18nController.ts
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import DictionaryHandler from './DictionaryHandler';
 import { getConfiguration } from '../extension';
 import { getDistanceBetweenDirectories } from '../utils';
-import { Dictionary } from '../types';
+import type { Dictionary } from '../types';
 
 class I18nController {
   dictionaryHandlerList: DictionaryHandler[];
@@ -62,7 +62,7 @@ class I18nController {
     for (const currentPath of pathList) {
       const isDirectory = fs.lstatSync(currentPath).isDirectory();
 
-      let value;
+      let value: Dictionary;
       if (isDirectory) {
         value = await this.createDictionary(currentPath);
       } else {
@@ -93,7 +93,7 @@ class I18nController {
     return dictionary;
   }
 
-  setClosestDictionaryHandler(uriPath?: string) {
+  setClosestDictionaryHandler(uriPath?: string): void {
     if (!uriPath) {
       return;
     }
@@ -109,10 +109,9 @@ class I18nController {
         this.selectedDictionaryHandler = dictionaryHandler;
       }
     }
-    return this.selectedDictionaryHandler;
   }
 
-  getTooltipContents(i18nKey: string) {
+  getTooltipContents(i18nKey: string): vscode.MarkdownString {
     const selectedDictionaryHandler = this.selectedDictionaryHandler;
     const localeList = Object.keys(selectedDictionaryHandler.dictionary);
     const internationalizedStringList = localeList.map((locale) => {

--- a/src/core/i18nTextHandler.ts
+++ b/src/core/i18nTextHandler.ts
@@ -10,15 +10,15 @@ import { getConfiguration } from '../extension';
 export function getI18nKeyOnHoveredPosition(
   _document: vscode.TextDocument,
   _position: vscode.Position,
-) {
+): string | null {
   const range = getRangeOfI18nText(_document, _position);
   if (!range) {
-    return;
+    return null;
   }
 
   const i18nKey = getI18nKeyInRange(_document, range);
   if (!i18nKey) {
-    return;
+    return null;
   }
 
   return i18nKey;
@@ -27,10 +27,10 @@ export function getI18nKeyOnHoveredPosition(
 function getRangeOfI18nText(
   _document: vscode.TextDocument,
   _position: vscode.Position,
-) {
+): vscode.Range | null {
   const i18nOpeningPosition = getI18nOpeningPosition(_document, _position);
   if (!i18nOpeningPosition) {
-    return;
+    return null;
   }
 
   const i18nClosingPosition = getI18nClosingPosition(
@@ -41,7 +41,7 @@ function getRangeOfI18nText(
     !i18nClosingPosition ||
     comparePosition(i18nClosingPosition, _position) <= 0
   ) {
-    return;
+    return null;
   }
 
   return new vscode.Range(i18nOpeningPosition, i18nClosingPosition);
@@ -50,11 +50,11 @@ function getRangeOfI18nText(
 function getI18nKeyInRange(
   _document: vscode.TextDocument,
   range: vscode.Range,
-) {
+): string | null {
   const { i18nPattern } = getConfiguration();
 
   const targetWord = _document.getText(range).replace(/\s/g, '');
-  const i18nKey = i18nPattern.exec(targetWord)?.[1];
+  const i18nKey = i18nPattern.exec(targetWord)?.[1] ?? null;
   return i18nKey;
 }
 
@@ -123,7 +123,7 @@ function getI18nClosingPosition(
 function comparePosition(
   leftP: vscode.Position,
   rightP: vscode.Position,
-): Number {
+): number {
   if (leftP.line !== rightP.line) {
     return leftP.line - rightP.line;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,13 +50,12 @@ export async function activate(context: vscode.ExtensionContext) {
         _position: vscode.Position,
         _token: vscode.CancellationToken,
       ): vscode.ProviderResult<vscode.Hover> {
-        const selectedDictionaryHandler =
-          i18nController.setClosestDictionaryHandler(
-            vscode.window.activeTextEditor?.document.uri.path,
-          );
+        i18nController.setClosestDictionaryHandler(
+          vscode.window.activeTextEditor?.document.uri.path,
+        );
 
         if (
-          !selectedDictionaryHandler ||
+          !i18nController.selectedDictionaryHandler ||
           !Object.keys(i18nController.selectedDictionaryHandler.dictionary)
             .length
         ) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import type { Dictionary } from './types';
 export function flattenObject(parentObject: object) {
   let object: object = parentObject;
   while (Object.values(object).some((value) => typeof value === 'object')) {
-    object = Object.entries(object).reduce((obj: any, [key, subObject]) => {
+    object = Object.entries(object).reduce((obj: object, [key, subObject]) => {
       if (typeof subObject === 'object') {
         return { ...obj, ...subObject };
       }
@@ -19,7 +19,7 @@ export function flattenObject(parentObject: object) {
   return object;
 }
 
-export function flattenDictionary(dictionary: Dictionary) {
+export function flattenDictionary(dictionary: Dictionary): Dictionary {
   return Object.entries(dictionary).reduce(
     (flattenedDictionary, [locale, subDictionary]) => {
       return {


### PR DESCRIPTION
- Specify the return type of every function and methods.
- Replace type `undefined` to `null`.
- Specify the type of variables where auto type inference does not work.
- Remove type `any`.
- Change `import` to `import type` where only type is required.